### PR TITLE
Fix access_callback function and avoid duplicated entity_save()

### DIFF
--- a/sermepa_payment.module
+++ b/sermepa_payment.module
@@ -60,7 +60,6 @@ function sermepa_payment_callback(Payment $payment) {
   $feedback = $sermepa->getFeedback();
   $response = $feedback['Ds_Response'];
   set_payment_final_status($response, $payment);
-  entity_save('payment', $payment);
 }
 
 
@@ -69,12 +68,11 @@ function sermepa_payment_access_callback(Payment $payment) {
   $amount = $payment->totalAmount(false) * 100;
   $feedback = $sermepa->getFeedback();
 
-  try {
-    $sermepa->checkFeedback($feedback, $amount);
+  if ($sermepa->validSignatures($feedback)) {
     watchdog('sermepa_payment', "Feedback for payment {$payment->pid} was valid. Access authorized.");
     return true;
-  } catch (SermepaException $e) {
-    watchdog('sermepa_payment', "Feedback for payment {$payment->pid} was NOT valid.\nAcces NOT authorized. \nError was: {$e->getMessage()}");
+  } else {
+    watchdog('sermepa_payment', "Feedback for payment {$payment->pid} was NOT valid.\nAcces NOT authorized.");
     return false;
   }
 }
@@ -233,5 +231,5 @@ function set_payment_final_status($response, $payment) {
     }
   }
 
-    entity_save('payment', $payment);
+  entity_save('payment', $payment);
 }


### PR DESCRIPTION
This PR fixes three issues:

- As can be seen [here](https://github.com/CommerceRedsys/sermepa/blob/master/CHANGELOG.md), the `$sermepa->checkFeedback()` method was renamed twice, and currently it's `$sermepa->validSignatures()`. This produced a fatal error in the module's payment callback function, making it impossible to properly make payments.
- A major security flaw in the `sermepa_payment_access_callback()` function. Because it was using a try-catch block, and the feedback-checking function just returns (and has always returned) `true` or `false` and never raises an exception, the access check would always return `true`, regardless of the feedback validation. This basically means it was possible to validate any payment by just going to _sermepa/callback/%entity_object_ in a web browser.
- Avoid a double call to `entity_save()` in the `sermepa_payment_callback()` function.