### PR TITLE
Add field "payment_code" to Payment Plugin

### DIFF
--- a/sermepa_payment.module
+++ b/sermepa_payment.module
@@ -1,1 +1,15 @@
 <?php
+use Drupal\Core\Entity\EntityTypeInterface;
+use Drupal\Core\Field\BaseFieldDefinition;
+
+/**
+ * Add a field "payment_code" to the payment table
+ * Implements hook_entity_base_field_info().
+ */
+function sermepa_payment_entity_base_field_info(EntityTypeInterface $entity_type) {
+  if ($entity_type->id() === 'payment') {
+    $fields['payment_code'] = BaseFieldDefinition::create('string')
+      ->setLabel(t('Payment Code'));
+    return $fields;
+  }
+}

--- a/src/Plugin/Payment/Method/Sermepa.php
+++ b/src/Plugin/Payment/Method/Sermepa.php
@@ -56,7 +56,9 @@ class Sermepa extends PaymentMethodBaseOffsite implements PaymentMethodOffsiteIn
       ->toString();
 
     // Configure gateway
-    $gateway->setOrder($payment->id());
+    //The Order (MERCHANT_ORDER_ID) has to be an alphanumeric string starting with 4 numbers and with a max lengt of 12
+    //https://canales.redsys.es/canales/ayuda/documentacion/Manual%20integracion%20para%20conexion%20por%20Web%20Service.pdf
+    $gateway->setOrder($payment->payment_code->value ?? $payment->id());
     $gateway->setAmount($sermepa_price);
     $gateway->setMerchantUrl($callback_url);
     $gateway->setCurrency($this->pluginDefinition['config']['merchant_currency']);


### PR DESCRIPTION
We need a new field in the payment code called "payment_code",
this "payment_code" will be send as DS_MERCHANT_ORDER to redsys API.

This code sent to redsys API has to be an alphanumeric string,
begining by 4 numbers and with a max lenght of 12.

Doc: https://canales.redsys.es/canales/ayuda/documentacion/Manual%20integracion%20para%20conexion%20por%20Web%20Service.pdf